### PR TITLE
Adding missing bibl divs

### DIFF
--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.33.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.33.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?><TEI xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://www.tei-c.org/ns/1.0">
+<?xml version="1.0" encoding="UTF-8"?><?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
+<TEI xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://www.tei-c.org/ns/1.0">
 	<teiHeader>
 		<fileDesc>
 			<titleStmt>
@@ -70,13 +71,14 @@
 					<placeName ref="europe.rome.italy" key="423052">necropolis of San Paolo fuori le Mura, Via Ostiense, Rome, Italy</placeName>
 					<date notBefore="0001" notAfter="0100">first century CE</date>
 				</origin>
-				<provenance type="found" subtype="first-recorded">
-					<date notAfter="1899-12-31">1899</date>
-					<placeName ref="NY.NY.CU">in the handwritten catalogue in Butler library, George N. Olcott mentions this inscription coming from the same provenance as those documented in an article published in 1899</placeName>
+                <provenance type="found" subtype="first-recorded">
+                	<p><persName>George N. Olcott</persName> mentions this inscription coming from the same provenance as those documented in an article published in <date notAfter="1899-12-31">1899</date> in the handwritten catalogue in <placeName ref="NY.NY.CU">Butler Library</placeName></p>
 				</provenance>
-				<provenance type="observed">
-					<date notAfter="2011-09-01">2011</date>
-					<placeName ref="NY.NY.CU">identified in the Butler library collection no later than 1st September 2011</placeName>
+                <provenance type="transferred" subtype="purchase">
+                	<p><p><persName>George N. Olcott</persName> records purchasing this inscription from the excavation of the <placeName>Via Ostiensis necropolis</placeName> near <placeName>San Paolo fuori le Mura</placeName> in <placeName>Rome</placeName>.</p></p>
+                </provenance>
+				<provenance type="observed" subtype="autopsy">
+					<p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection no later than <date notAfter="2011-09-01">1st September 2011</date></p>
 				</provenance>
 			</history>
 			<additional>
@@ -105,6 +107,7 @@
 		<change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style; added commentary div; formatted translation; fixed origin elements, cleaned provenance</change>
 		<change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
 			<change when="2020-03-22" who="Gaia Gianni">Delete image filename</change>
+		<change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
 	</revisionDesc>
 </teiHeader>
 <facsimile>
@@ -132,8 +135,7 @@
             
         
         
-                <div type="commentary">
-			<p>George N. Olcott records purchasing this inscription from the excavation of the Via Ostiensis necropolis near San Paolo fuori le Mura in Rome.</p>
+                <div type="commentary">			
 			<p>The modules and spacing between letters are inconsistent, as though the inscriber ran out of space. In particular, the first and last characters of line 2, an 'L' and an 'I' are not equidistant to the border, suggesting that the lettering was inscribed after the border. Note also the uneven spacing of the word 'Manibus' on line 1.</p>
 		</div>
             
@@ -142,7 +144,8 @@
                 <div type="apparatus">
                     <p/>
                 </div>
-            
+        	<div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
+        	
         
         
         </body>

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.34.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.34.xml
@@ -69,13 +69,11 @@
                             <placeName ref="europe.italy.rome" key="423025">Italy, Rome, Via Ostiense, necropolis of San Paolo fuori le Mura</placeName>
                             <date notBefore="0001" notAfter="0100">first century CE</date>                                                                
                         </origin>
-                        <provenance type="found" subtype="first-recorded">
-                            <date notAfter="1899-12-31">1899</date>
-                            <placeName ref="NY.NY.CU">George N. Olcott records purchasing this inscription from the excavation of the Via Ostiensis necropolis near San Paolo fuori le Mura in Rome, and mentions this inscription coming from the same provenance as those documented in a previous publication from 1899</placeName>
+                        <provenance type="transferred" subtype="purchase">
+                            <p><persName>George N. Olcott</persName> records purchasing this inscription from the excavation of the <placeName>Via Ostiensis necropolis</placeName> near <placeName>San Paolo fuori le Mura</placeName> in <placeName>Rome</placeName>, and mentions this inscription coming from the same provenance as those documented in a previous publication from <date notAfter="1899-12-31">1899</date></p>
                         </provenance>
                         <provenance type="observed">
-                            <date notAfter="2011-09-01">2011</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection no later than 1 September 2011</placeName>
+                            <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection no later than <date notAfter="2011-09-01">1 September 2011</date></p>
                         </provenance> 
                     </history> 
                     <additional>
@@ -103,6 +101,7 @@
             <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style, fixed origin elements</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
             <change when="2020-03-22" who="Gaia Gianni">Deleted image filename</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -137,7 +136,7 @@
                 <div type="apparatus">
                     <p/>
                 </div>
-            
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         
         </body>

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.37.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.37.xml
@@ -57,7 +57,7 @@
 						</handNote>
 					</handDesc>
 					<decoDesc>
-						<decoNote ana="#blank">
+						<decoNote ana="">
 							<p/>
 						</decoNote>
 					</decoDesc>
@@ -71,13 +71,10 @@
 						<date notBefore="0001" notAfter="0100">first century CE</date>
 					</origin>
 					<provenance type="found">
-						<date when="1899">1899</date>
-						<placeName ref="NY.NY.CU">George N. Olcott records this inscription as "From Via Salaria, as the preceding" (i.e. NY.NY.CU.Butl.L.34)</placeName>
+						<p><persName>George N. Olcott</persName> records this inscription as "From <placeName>Via Salaria</placeName>, as the preceding" (i.e. NY.NY.CU.Butl.L.34) in <date when="1899">1899</date></p>
 					</provenance>
 					<provenance type="observed">
-						<date notAfter="2011-09-01">2011</date>
-						<placeName ref="NY.NY.CU">identified in the Butler library collection not later than 1 September 2011</placeName>
-					</provenance>
+<p>					Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than <date notAfter="2011-09-01">1 September 2011</date></p>				</provenance>
 				</history>
 				<additional>
 					<surrogates/>
@@ -105,6 +102,7 @@
 		<change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style</change>
 		<change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
 		<change when="2016-04-13" who="Scott J. DiGiulio">Fixed language</change>
+		<change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
 	</revisionDesc>
 	</teiHeader>
 	<facsimile>
@@ -141,7 +139,7 @@
                     <p/>
                 </div>
             
-        
+        	<div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         </body>
         

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.39.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.39.xml
@@ -71,12 +71,10 @@
                             <date notBefore="-0050" notAfter="0100">late first century BCE to first century CE</date>
                         </origin>
                         <provenance type="found" subtype="first-recorded">
-                            <date notAfter="1899-12-31">1899</date>
-                            <placeName ref="NY.NY.CU">in the handwritten catalogue in Butler library George N. Olcott records this inscription as coming "from a columbarium on the Via Salaria, as the preceding" (i.e. NY.NY.CU.Butl.L.38), and that this columbarium "now destroyed...(was) not far from the gate"</placeName>
+                            <p>In the handwritten catalogue in <placeName ref="NY.NY.CU">Butler library</placeName>, in <date notAfter="1899-12-31">1899</date> <persName>George N. Olcott</persName> records this inscription as coming "from a columbarium on the <placeName>Via Salaria</placeName>, as the preceding" (i.e. NY.NY.CU.Butl.L.38), and that this columbarium "now destroyed...(was) not far from the gate"</p>
                         </provenance>
                         <provenance type="observed">
-                            <date notAfter="2011-09-01">2011</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection not later than 1 September 2011</placeName>
+                            <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than <date notAfter="2011-09-01">1 September 2011</date></p>
                         </provenance>
                     </history>
                     <additional>
@@ -105,6 +103,7 @@
             <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
             <change when="2020-03-29" who="Gaia Gianni">Deleted image filename</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -139,7 +138,7 @@
                 <div type="apparatus">
                     <p/>
                 </div>
-            
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         
         </body>

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.41.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.41.xml
@@ -70,12 +70,10 @@
                             <date notBefore="0001" notAfter="0100">first century CE</date>
                         </origin>
                         <provenance type="found" subtype="first-recorded">
-                            <date notAfter="1899-12-31">1899</date>
-                            <placeName ref="NY.NY.CU">in the handwritten catalogue in Butler library, George N. Olcott records this inscription as coming "From the Via Salaria, as the preceding" (i.e. NY.NY.CU.Butl.L.34)</placeName>
+                            <p>In the handwritten catalogue in <placeName ref="NY.NY.CU">Butler library</placeName>, in <date notAfter="1899-12-31">1899</date> <persName>George N. Olcott</persName> records this inscription as coming "From the <placeName>Via Salaria</placeName>, as the preceding" (i.e. NY.NY.CU.Butl.L.34)</p>
                   </provenance>
-                        <provenance type="observed" notAfter="2011-09-01">
-                            <date notAfter="2011-09-01">2011</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection not later than 1 September 2011</placeName>
+                        <provenance type="observed" >
+                             <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than  <date notAfter="2011-09-01">1 September 2011</date></p>                          
                         </provenance>
                     </history>
                     <additional>
@@ -104,6 +102,7 @@
             <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style, corrected origin</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
             <change when="2020-03-22" who="Gaia Gianni">Deleted image filename</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -144,7 +143,7 @@
                     <p/>
                 </div>
             
-        
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         </body>
         

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.419.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.419.xml
@@ -62,7 +62,7 @@
                             <handNote ana="#impressed.inscribed.chiseled">guide lines are visible in the main body of text</handNote>
                         </handDesc>
                         <decoDesc>
-                            <decoNote ana="#blank">
+                            <decoNote ana="">
                             </decoNote>
                         </decoDesc>
                     </physDesc>
@@ -74,9 +74,8 @@
                             <placeName ref="unknown">unknown</placeName>
                             <date notBefore="0100" notAfter="0299">second or third century CE</date>
                         </origin>
-                        <provenance type="observed">
-                            <date notAfter="2012-10-19">2012</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection not later than 19 October 2012</placeName>
+                        <provenance type="observed" subtype="autopsy">
+                            <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than <date notAfter="2012-10-19">19 October 2012</date></p>
                         </provenance>
                     </history>
                     <additional>
@@ -109,6 +108,7 @@
             <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style; added commentary div and moved part of handNote there; small edits to transcrpition</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
             <change when="2020-03-22" who="Gaia Gianni">Deleted image filename</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -150,6 +150,7 @@
                 <div type="apparatus">
                     <p/>
                 </div>
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
             
         
         

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.42.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.42.xml
@@ -70,12 +70,10 @@
                             <date notBefore="0001" notAfter="0100">first century CE</date>
                         </origin>
                         <provenance type="found" subtype="first-recorded">
-                            <date notAfter="1899-12-31">1899</date>
-                            <placeName ref="NY.NY.CU">in the handwritten catalogue in Butler library, George N. Olcott records this inscription as coming "From Via Salaria, as the preceding" (i.e. NY.NY.CU.Butl.L.34)</placeName>
+                            <p>In the handwritten catalogue in <placeName ref="NY.NY.CU">Butler library</placeName>, <persName>George N. Olcott</persName> records this inscription as coming "From <placeName>Via Salaria</placeName>, as the preceding" (i.e. NY.NY.CU.Butl.L.34) in <date notAfter="1899-12-31">1899</date></p>
                         </provenance>
                         <provenance type="observed">
-                            <date notAfter="2011-09-01">2011</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection not later than 1 September 2011</placeName>
+                            <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than <date notAfter="2011-09-01">1 September 2011</date></p>
                         </provenance>
                     </history>
                     <additional>
@@ -104,6 +102,7 @@
             <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style; added commentary div and moved part of handNote there, fixed elements in origin</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
             <change when="2020-03-22" who="Gaia Gianni">Deleted image filename</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -139,7 +138,7 @@
                 <div type="apparatus">
                     <p/>
                 </div>
-            
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         
         </body>

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.420.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.420.xml
@@ -70,14 +70,13 @@
                             <placeName ref="unknown">unknown</placeName>
                             <date notBefore="0100" notAfter="0300">second or third century CE</date>
                         </origin>
+                        <provenance type="transferred" subtype="purchase">
+                          <p>Purchased by the Drisler Fund for the <placeName ref="NY.NY.CU">Columbia University</placeName> Latin Department as mentioned in the spring edition of the <date when="1901">1901</date> Columbia Quarterly, pp.189-190</p>
+                        </provenance>
                         <provenance type="observed">
-                            <date notAfter="2011-09-01">2011</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection not later than 1 September 2011</placeName>
+                          <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than <date notAfter="2011-09-01">1 September 2011</date></p>
                         </provenance>
-                        <provenance>
-                            <date when="1901">1901</date>
-                            <placeName ref="NY.NY.CU">purchased by the Drisler Fund for the Columbia University Latin Department as mentioned in the spring edition of the 1901 Columbia Quarterly, pp.189-190</placeName>
-                        </provenance>
+                        
                     </history>
                     <additional>
                         <surrogates>
@@ -108,6 +107,7 @@
             <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style; added commentary div and moved text note; edits to transcrpition regularization</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
             <change when="2020-03-22" who="Gaia Gianni">Deleted image filename</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -150,7 +150,7 @@
                     <p/>
                 </div>
             
-        
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         </body>
         

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.422.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.422.xml
@@ -72,8 +72,7 @@
                             <placeName ref="unknown">unknown</placeName>
                         </origin>
                         <provenance type="observed">
-                            <date notAfter="2011-09-01">2011</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection not later than 1st September 2011</placeName>
+                            <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than <date notAfter="2011-09-01">1st September 2011</date></p>
                         </provenance>
                     </history>
                     <additional>
@@ -104,6 +103,7 @@
             <change when="2015-02-13" who="Joe Sheppard">Final revision for upload to github; new text for origPlace; spaces added around glyphs in text.</change>
             <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style; added commentary div and added notes from elsewhere; fixed orig elements; added punctuation to transcription</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -143,7 +143,7 @@
                     <p/>
                 </div>
             
-        
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         </body>
         

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.424.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.424.xml
@@ -66,12 +66,10 @@
                             <date notBefore="0070" notAfter="0100">late-1st century CE</date>
                         </origin>
                         <provenance type="observed" subtype="recorded">
-                            <date notAfter="1901-03-31">1901</date>
-                            <placeName ref="NY.NY.CU">recorded as being in the possession of the Latin department in The Columbia University Quarterly, March 1901</placeName>
+                            <p>Recorded as being in the possession of the Latin department in The Columbia University Quarterly, <date notAfter="1901-03-31">March 1901</date></p>
                         </provenance>
                         <provenance type="observed">
-                            <date notAfter="2011-09-01">2011</date>
-                            <placeName ref="NY.NY.CU">identified in the Butler library collection not later than 1 September 2011</placeName>
+                            <p>Identified in the <placeName ref="NY.NY.CU">Butler library</placeName> collection not later than <date notAfter="2011-09-01">1 September 2011</date></p>
                         </provenance>
                     </history>
                     <additional>
@@ -101,6 +99,7 @@
             <change when="2014-02-06" who="Joe Sheppard">updated bibliography, summary, provenance</change>
             <change when="2016-03-02" who="Scott J. DiGiulio">Corrected language code, corrected xi:include  directory, corrected provenance p to placeName</change>
             <change when="2020-03-22" who="Gaia Gianni">Deleted image filename</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -148,7 +147,7 @@
                 <div type="apparatus">
                     <p/>
                 </div>
-            
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         
         </body>

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.431.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.431.xml
@@ -77,7 +77,7 @@
                     <msContents>
                         <textLang mainLang="lat"/> <!-- la, grc, ett ?? -->
                         <msItem class="#funerary.epitaph">
-                        <p>Epitaph for Gnaeus Flavius Apollonius, freedman of Gnaeus, and Papia Dioclea, freedwoman of Lucius.</p>
+                        <p>Epitaph for Gnaeus Flavius Apollonius, freedman of Gnaeus, and Papia Dioclea, freedwoman of Lucius</p>
                         </msItem>
                     </msContents>
 
@@ -117,7 +117,7 @@
                             <supportDesc ana="#stone.marble">
 
                                 <support>
-                                    <p>Marble columbarium slab. Reverse seems to indicate the stone is a repurposed sculpture fragment.</p>
+                                    <p>Marble columbarium slab</p>
                                     
                                     
                                      <dimensions type="surface" unit="cm">
@@ -128,7 +128,7 @@
                                </support>
 
                                 <condition ana="#complete.intact">
-                                    <p>margin lines still visible on all 4 edges, indicating an original 16.5 cm square campus. "A19" written in pencil on stone face</p>
+                                    <p>margin lines still visible on all 4 edges, indicating an original 16.5 cm square campus. "A19" written in pencil on stone face. Reverse seems to indicate the stone is a repurposed sculpture fragment.</p>
                                 </condition>
 
                             </supportDesc>
@@ -168,8 +168,8 @@
                         -->
 
                         <decoDesc>
-                            <decoNote type="blank">
-                                <p>no decoration</p>
+                            <decoNote type="">
+                                <p></p>
                             </decoNote>
                         </decoDesc>
                     </physDesc>
@@ -263,6 +263,7 @@
         -->
         <revisionDesc>
             <change when="2011-12-08" who="Joe McDonald">Initial Encoding</change>
+            <change when="2020-05-19" who="Scott J. DiGiulio">Added name markup to transcription; added translation; added missing bibl div</change>
         </revisionDesc>
 
     </teiHeader>
@@ -288,17 +289,17 @@
         <body>
         <div type="edition">
                 <ab>
-                    <lb n="1"/><expan><abbr>Gn</abbr><ex>aeus</ex></expan> Flavius <expan><abbr>Gn</abbr><ex>aei</ex></expan> <expan><abbr>l</abbr><ex>ibertus</ex></expan>
-                    <lb n="2"/> Apollonius et
-                    <lb n="3"/> Papia <expan><abbr>L</abbr><ex>ucii</ex></expan> <expan><abbr>l</abbr><ex>iberta</ex></expan> Dioclea.
-                    <lb n="4"/> Horum ossa h<hi rend="tall">i</hi>c
-                    <lb n="5"/> sita sunt.
-                    <lb n="6"/> Vale.</ab>
+                    <lb n="1"/><persName><name type="praenomen" key="Gnaeus"><expan><abbr>Gn</abbr><ex>aeus</ex></expan></name> <name type="gentilicium" key="Flavius">Flavius</name> <persName><name type="praenomen" key="Gnaeus"><expan><abbr>Gn</abbr><ex>aei</ex></expan></name></persName> <expan><abbr>l</abbr><ex>ibertus</ex></expan>
+                    <lb n="2"/><name type="cognomen" key="Apollonius">Apollonius</name></persName> et
+                    <lb n="3"/><persName><name type="gentilicium" key="Papia">Papia</name> <persName><name type="praenomen" key="Lucius"><expan><abbr>L</abbr><ex>ucii</ex></expan></name></persName> <expan><abbr>l</abbr><ex>iberta</ex></expan> <name type="cognomen" key="Dioclea">Dioclea</name></persName>.
+                    <lb n="4"/>Horum ossa h<hi rend="tall">i</hi>c
+                    <lb n="5"/>sita sunt.
+                    <lb n="6"/>Vale.</ab>
             </div>
         
         
-                <div type="translation">
-                    <p/>
+                <div type="translation" xml:lang="en">
+                    <p>Gnaeus Flavius Apollonius, freedman of Gnaeus, and Papia Dioclea, freedwoman of Lucius. The bones of these people are buried here. Farewell.</p>
                 </div>
             
         
@@ -313,7 +314,7 @@
                     <p/>
                 </div>
             
-        
+            <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         </body>
         

--- a/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.444.xml
+++ b/xml_inscriptions/transcribed/NY.NY.CU.Butl.L.444.xml
@@ -72,12 +72,10 @@
                      <date notBefore="-0100" notAfter="0001" cert="low">first century BCE</date>
                   </origin>
                   <provenance type="observed" subtype="recorded">
-                     <date notAfter="1901-03-31">1901</date>
-                     <p>recorded as being in the possession of the Latin department in the March, 1901 edition of the Columbia University Quarterly</p>
+                     <p>Recorded as being in the possession of the Latin department in the <date notAfter="1901-03-31">March, 1901</date> edition of the <placeName>Columbia University</placeName> Quarterly</p>
                   </provenance>
                   <provenance type="observed">
-                     <date notAfter="2011-09-01">2011</date>
-                     <p>identified in the Butler library collection no later than 1 September 2011</p>
+                     <p>Identified in the <placeName>Butler library</placeName> collection no later than <date notAfter="2011-09-01">1 September 2011</date></p>
                   </provenance>
                </history>
                <additional>
@@ -105,6 +103,7 @@
          <change when="2013-07-23" who="Joe Sheppard">translated initial data to EpiDoc</change>
          <change when="2014-11-14" who="Joe Sheppard">revision of first draft; request for further revision by another editor</change>
          <change when="2016-02-29" who="Scott J. DiGiulio">Proofed xml document for conformity to USEP standards and style; fixed elements in origin, added bibl, formatted other metadata, proofed transcription</change>
+         <change when="2020-05-19" who="Scott J. DiGiulio">Changed provenance information to match new USEP standards; added missing bibl div</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>
@@ -148,7 +147,7 @@
                     <p/>
                 </div>
             
-        
+           <div type="bibliography"> <xi:include href="http://library.brown.edu/usep_data/resources/titles.xml"> <xi:fallback> <p>US Ep bibliography</p> </xi:fallback> </xi:include> </div>
         
         </body>
         


### PR DESCRIPTION
Adding missing `<div type="bibl">`s where needed; also reformulated some `<provenance>` entries to conform to the way we are now handling. Close #139.